### PR TITLE
Allow adding up to four materials

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   <button id="merge-btn">Fusionar</button>
   <div id="new-materials"><h3>Material Nuevo</h3></div>
   <script>
-    const MAX_ADD = 3;
+    const MAX_ADD = 4;
     const totalQuantities = {}, addedQuantities = {};
     let materials = [];
 
@@ -80,7 +80,7 @@
 
     function renderAddedList() {
       const container = document.getElementById('added-list'), totalAdded = getTotalAdded();
-      container.innerHTML = `<h3>Materiales Añadidos (${totalAdded}/3)</h3>`;
+      container.innerHTML = `<h3>Materiales Añadidos (${totalAdded}/${MAX_ADD})</h3>`;
       materials.forEach(m => {
         if (addedQuantities[m.id] > 0) {
           const div = document.createElement('div');


### PR DESCRIPTION
## Summary
- raise material addition limit from three to four and show new cap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b25943e648320bcd6fe82cb55590c